### PR TITLE
wrap references to resources in static-ref's Ref/RefMut

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ syn = "0.11.10"
 [dependencies]
 cortex-m = "0.2.2"
 typenum = "1.7.0"
+static-ref = { git = "https://github.com/japaric/static-ref" }
 
 [dev-dependencies]
 compiletest_rs = "0.2.5"

--- a/tests/cfail/claim_mut.rs
+++ b/tests/cfail/claim_mut.rs
@@ -8,26 +8,26 @@ static R1: Resource<i32, C2> = Resource::new(0);
 
 fn j1(mut prio: P2) {
     // OK only one `&mut-` reference to the data
-    let r1: &mut i32 = R1.claim_mut(&mut prio);
+    let r1 = R1.claim_mut(&mut prio);
 }
 
 fn j2(prio: P2) {
     // OK two `&-` references to the same data
-    let r1: &i32 = R1.claim(&prio);
-    let another_r1: &i32 = R1.claim(&prio);
+    let r1 = R1.claim(&prio);
+    let another_r1 = R1.claim(&prio);
 }
 
 fn j3(mut prio: P2) {
     // CAN'T have a `&-` reference and a `&mut-` reference to the same data
-    let r1: &i32 = R1.claim(&prio);
-    let another_r1: &mut i32 = R1.claim_mut(&mut prio);
+    let r1 = R1.claim(&prio);
+    let another_r1 = R1.claim_mut(&mut prio);
     //~^ error
 }
 
 fn j4(mut prio: P2) {
     // CAN'T have two `&mut-` references to the same data
-    let r1: &mut i32 = R1.claim_mut(&mut prio);
-    let another_r1: &mut i32 = R1.claim_mut(&mut prio);
+    let r1 = R1.claim_mut(&mut prio);
+    let another_r1 = R1.claim_mut(&mut prio);
     //~^ error
 }
 


### PR DESCRIPTION
to assert that they point to `static` data